### PR TITLE
feat(app): initial routing + themed UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,53 @@
+## Checklist inicial
+
 - [x] Verificar que el archivo copilot-instructions.md en la carpeta .github existe.
 - [x] Clarificar requerimientos del proyecto: React, Vite, TypeScript, Material-UI, Icons, @mui/lab, Zustand, Router, ESLint, Prettier, absolute imports.
 - [x] Crear estructura y dependencias principales.
 - [x] Personalizar el proyecto según requerimientos iniciales.
+- [x] Configurar alias `@` y funcionamiento en editor y build.
+- [x] Añadir configuración ESLint + Prettier + sort imports + format on save.
 - [ ] Instalar extensiones necesarias (si aplica).
 - [x] Compilar el proyecto y resolver problemas.
-- [ ] Crear y ejecutar tareas (si aplica).
-- [ ] Lanzar el proyecto (debug/producción).
+- [ ] Crear y ejecutar tareas (VSCode tasks) (pendiente si se requieren scripts específicos).
+- [ ] Lanzar el proyecto en modo debug (pendiente configuración launch.json si se necesita).
 - [x] Documentar en README.md y copilot-instructions.md.
+- [x] Inicializar repo Git y crear commit inicial.
+- [x] Crear rama feature/login-ui.
+- [x] Implementar Login UI inicial + routing + 404.
 
-Resumen: Proyecto inicial listo, dependencias instaladas, configuración de ESLint, Prettier y absolute imports aplicada. Puedes comenzar a desarrollar tu gestor de tareas Azure.
+## Tema (Theme) Global
+
+Ruta del archivo de tema principal: `src/theme/theme.ts`.
+
+- Paleta primaria y secundaria basada en escala `scooter` definida manualmente.
+- Se debe reutilizar `theme.palette` para colores en componentes nuevos (evitar hardcodear hex excepto transparencias con `alpha`).
+- Para fondos degradados preferir combinar `theme.palette.primary.dark`, `theme.palette.primary.main`, `theme.palette.secondary.dark`.
+- Para overlays translúcidos usar `alpha(theme.palette.common.white, x)` o `alpha(theme.palette.common.black, x)` según contraste.
+
+## Rutas actuales
+
+- `/login` (Lazy) -> LoginPage.
+- `/dashboard` (Lazy, protegida simple mediante flag en `sessionStorage`).
+- `/*` -> NotFoundPage.
+
+## Autenticación (temporal)
+
+- Mock local con usuario y contraseña en `LoginPage` (const `MOCK_USER`).
+- Flag de sesión: `sessionStorage.setItem('auth', '1')`.
+- TODO: Migrar a Firebase Auth (email/password) y manejar estado global con Zustand.
+
+## Próximos pasos sugeridos
+
+1. Añadir capa de estado global de auth con Zustand (`/src/store/auth.ts`).
+2. Sustituir mock por Firebase Auth.
+3. Implementar guard más robusto (redirect si ya autenticado y visita `/login`).
+4. Añadir layout protegido (app bar, navegación lateral) para `/dashboard` y futuras páginas.
+5. Configurar scripts de verificación pre-commit (husky + lint-staged) si se desea.
+
+Resumen: Proyecto base listo con tema central en `src/theme/theme.ts`, login estilizado acorde a la paleta, routing con protección básica y estructura preparada para evolución (Firebase + Zustand).
+
+## Reglas de flujo de trabajo
+
+- No sugerir ni ejecutar commits, pushes o creación de ramas adicionales a menos que el usuario lo solicite explícitamente.
+- Priorizar uso del tema desde `src/theme/theme.ts` para cualquier color / fondo.
+- Mantener imports absolutos con alias `@`.

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "mui-mcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@mui/mcp@latest"]
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always",
+    "source.fixAll.eslint": "always"
+  },
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.preferences.importModuleSpecifierEnding": "auto",
+  "javascript.preferences.importModuleSpecifierEnding": "auto",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,5 @@
-function App() {
-  return (
-    <div>
-      <h1>Gestor de Tareas Azure</h1>
-    </div>
-  );
-}
+import AppRouter from '@/routes/AppRouter';
 
-export default App;
+export default function App() {
+  return <AppRouter />;
+}

--- a/src/components/AppBackground.tsx
+++ b/src/components/AppBackground.tsx
@@ -1,0 +1,33 @@
+import { Box } from '@mui/material';
+import { alpha, styled } from '@mui/material/styles';
+import type { PropsWithChildren } from 'react';
+
+/**
+ * Reusable branded background with animated soft star/nebula style highlights.
+ * Centralizes the gradient logic so pages (login, 404, auth flows) stay consistent.
+ */
+const Root = styled(Box)(({ theme }) => {
+  const p = theme.palette;
+  return {
+    minHeight: '100vh',
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    overflow: 'hidden',
+    background: `linear-gradient(140deg, ${p.primary.dark} 0%, ${p.primary.main} 45%, ${p.secondary.dark} 100%)`,
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      backgroundImage: `radial-gradient(circle at 18% 28%, ${alpha(p.common.white, 0.18)}, transparent 60%),
+        radial-gradient(circle at 82% 72%, ${alpha(p.common.white, 0.12)}, transparent 55%)`,
+      pointerEvents: 'none',
+    },
+  };
+});
+
+export default function AppBackground({ children }: PropsWithChildren) {
+  return <Root>{children}</Root>;
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material';
+
+export default function DashboardPage() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4" fontWeight={600} gutterBottom>
+        Dashboard
+      </Typography>
+      <Typography variant="body1">Bienvenido. Aquí irán tus tareas Azure.</Typography>
+    </Box>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,149 @@
+import AppBackground from '@/components/AppBackground';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Container,
+  FormControlLabel,
+  IconButton,
+  InputAdornment,
+  Link,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const MOCK_USER = {
+  username: 'admin',
+  password: 'admin123',
+};
+
+// Background extraído a componente reutilizable AppBackground
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [remember, setRemember] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username === MOCK_USER.username && password === MOCK_USER.password) {
+      setError(null);
+      const storage = remember ? localStorage : sessionStorage;
+      storage.setItem('auth', '1');
+      navigate('/dashboard');
+    } else {
+      setError('Credenciales inválidas');
+    }
+  };
+
+  return (
+    <AppBackground>
+      <Container maxWidth="xs">
+        <Card
+          sx={(theme) => ({
+            background: theme.palette.common.white,
+            border: `1px solid ${theme.palette.common.white}`,
+            boxShadow: `0 8px 32px ${alpha(theme.palette.common.black, 0.3)}`,
+            color: theme.palette.common.black,
+          })}
+        >
+          <CardContent sx={{ p: 4 }}>
+            <Box display="flex" flexDirection="column" alignItems="center" mb={2}>
+              <Typography component="h1" variant="h5" fontWeight={700} color="primary">
+                Login
+              </Typography>
+            </Box>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <TextField
+                margin="normal"
+                fullWidth
+                label="Usuario"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                autoComplete="username"
+                autoFocus
+                variant="outlined"
+              />
+              <TextField
+                margin="normal"
+                fullWidth
+                label="Contraseña"
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                variant="outlined"
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          size="small"
+                          aria-label="Mostrar u ocultar contraseña"
+                          onClick={() => setShowPassword((s) => !s)}
+                          edge="end"
+                          color="primary"
+                        >
+                          {showPassword ? <VisibilityOff /> : <Visibility />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+              {error && (
+                <Typography variant="body2" color="error" mt={1}>
+                  {error}
+                </Typography>
+              )}
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                mt={1}
+                mb={1}
+              >
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={remember}
+                      onChange={(e) => setRemember(e.target.checked)}
+                    />
+                  }
+                  label={
+                    <Typography variant="caption" color="primary">
+                      Recordarme
+                    </Typography>
+                  }
+                />
+                <Link href="#" variant="caption" underline="hover" color="primary">
+                  Olvidé mi contraseña
+                </Link>
+              </Box>
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                size="large"
+                sx={{ mt: 1, mb: 2 }}
+              >
+                Ingresar
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+      </Container>
+    </AppBackground>
+  );
+}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,101 @@
+import AppBackground from '@/components/AppBackground';
+import { Button, Stack, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { useNavigate } from 'react-router-dom';
+
+function DecorativeWaves() {
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 1440 900"
+      preserveAspectRatio="xMidYMid slice"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        opacity: 0.32,
+        mixBlendMode: 'overlay',
+      }}
+    >
+      <defs>
+        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.35)" />
+          <stop offset="100%" stopColor="rgba(255,255,255,0.05)" />
+        </linearGradient>
+      </defs>
+      <path d="M0 600 Q360 520 720 600 T1440 600 V900 H0 Z" fill="url(#grad)" />
+      <path
+        d="M0 500 Q360 440 720 520 T1440 520 V900 H0 Z"
+        fill="url(#grad)"
+        opacity={0.6}
+      />
+      <path
+        d="M0 700 Q360 640 720 700 T1440 700 V900 H0 Z"
+        fill="url(#grad)"
+        opacity={0.4}
+      />
+    </svg>
+  );
+}
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <AppBackground>
+      <DecorativeWaves />
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        spacing={3}
+        sx={{
+          textAlign: 'center',
+          padding: { xs: 3, sm: 5 },
+          maxWidth: 640,
+          width: '100%',
+          '& > *:not(svg)': {
+            textShadow: '0 2px 10px rgba(0, 0, 0, 0.33)',
+          },
+        }}
+      >
+        <Typography
+          variant="h1"
+          color="primaryWhite"
+          sx={{
+            fontWeight: 800,
+            fontSize: { xs: '4.5rem', sm: '6rem' },
+            lineHeight: 1,
+            letterSpacing: '-3px',
+          }}
+        >
+          404
+        </Typography>
+        <Typography variant="h5" color="primaryWhite" fontWeight={700}>
+          Oops, esa página se desvaneció entre las nubes.
+        </Typography>
+        <Typography
+          variant="body2"
+          color="primaryWhite"
+          sx={{ maxWidth: 520, opacity: 0.92 }}
+        >
+          El recurso que buscas no existe o fue movido. Verifica la URL o regresa al
+          inicio para seguir navegando.
+        </Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ pt: 2 }}>
+          <Button
+            variant="contained"
+            onClick={() => navigate(-1)}
+            sx={(theme) => ({
+              background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+              boxShadow: `0 4px 16px -2px ${alpha(theme.palette.primary.dark, 0.5)}`,
+              color: theme.palette.primary.contrastText,
+            })}
+          >
+            Volver atrás
+          </Button>
+        </Stack>
+      </Stack>
+    </AppBackground>
+  );
+}

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -1,0 +1,41 @@
+import React, { lazy, Suspense } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+
+const LoginPage = lazy(() => import('@/pages/LoginPage'));
+const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
+const NotFoundPage = lazy(() => import('@/pages/NotFoundPage'));
+
+// Very small auth state mock (later replace with Zustand + Firebase)
+const isAuthenticated = () => {
+  // Check both sessionStorage and localStorage to support "Recordarme"
+  if (sessionStorage.getItem('auth') === '1') return true;
+  if (localStorage.getItem('auth') === '1') return true;
+  return false;
+};
+
+function PrivateRoute({ children }: { children: React.ReactElement }) {
+  if (!isAuthenticated()) return <Navigate to="/login" replace />;
+  return children;
+}
+
+export default function AppRouter() {
+  return (
+    <BrowserRouter>
+      <Suspense fallback={<div style={{ padding: 32 }}>Cargando...</div>}>
+        <Routes>
+          <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/dashboard"
+            element={
+              <PrivateRoute>
+                <DashboardPage />
+              </PrivateRoute>
+            }
+          />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
+    </BrowserRouter>
+  );
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 
-const scooter = {
+const colorPalette = {
   50: '#edfefe',
   100: '#d1fafc',
   200: '#a8f4f9',
@@ -14,27 +14,119 @@ const scooter = {
   950: '#0a3442',
 };
 
+// Module augmentation to add the new colors
+declare module '@mui/material/styles' {
+  interface Palette {
+    primaryWhite: Palette['primary'];
+  }
+  interface PaletteOptions {
+    primaryWhite?: PaletteOptions['primary'];
+  }
+  interface PaletteColor {
+    // Example if we later want custom tones
+  }
+}
+// Module augmentation to allow custom color in specific components
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    primaryWhite: true;
+  }
+}
+declare module '@mui/material/TextField' {
+  interface TextFieldPropsColorOverrides {
+    primaryWhite: true;
+  }
+}
+declare module '@mui/material/Checkbox' {
+  interface CheckboxPropsColorOverrides {
+    primaryWhite: true;
+  }
+}
+declare module '@mui/material/IconButton' {
+  interface IconButtonPropsColorOverrides {
+    primaryWhite: true;
+  }
+}
+declare module '@mui/material/Typography' {
+  interface TypographyPropsColorOverrides {
+    primaryWhite: true;
+  }
+}
+
+const BORDER_RADIUS = 8;
+
 const theme = createTheme({
   palette: {
     primary: {
-      main: scooter[500],
-      light: scooter[300],
-      dark: scooter[700],
+      main: colorPalette[500],
+      light: colorPalette[300],
+      dark: colorPalette[700],
       contrastText: '#fff',
     },
     secondary: {
-      main: scooter[400],
-      light: scooter[100],
-      dark: scooter[950],
+      main: colorPalette[400],
+      light: colorPalette[100],
+      dark: colorPalette[950],
       contrastText: '#fff',
     },
+    primaryWhite: {
+      main: colorPalette[50],
+      light: colorPalette[100],
+      dark: colorPalette[200],
+      contrastText: colorPalette[950],
+    },
     background: {
-      default: scooter[50],
-      paper: scooter[100],
+      default: colorPalette[50],
+      paper: colorPalette[100],
     },
     text: {
-      primary: scooter[950],
-      secondary: scooter[700],
+      primary: colorPalette[950],
+      secondary: colorPalette[700],
+    },
+  },
+  shape: {
+    borderRadius: BORDER_RADIUS,
+  },
+  components: {
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: BORDER_RADIUS,
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: BORDER_RADIUS,
+          textTransform: 'none',
+          fontWeight: 600,
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: BORDER_RADIUS,
+        },
+        notchedOutline: {
+          borderRadius: BORDER_RADIUS,
+        },
+      },
+    },
+    MuiFilledInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: BORDER_RADIUS,
+        },
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          borderRadius: BORDER_RADIUS,
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
Key additions:
- Routing with lazy pages (login, dashboard, 404) and simple auth guard
- New pages: LoginPage, DashboardPage, NotFoundPage
- Reusable gradient background component AppBackground
- 404 page creative design with decorative waves
- Login UI with mock auth + remember option (localStorage/sessionStorage)
- Theme refactor: custom colorPalette, primaryWhite variant, global border radius, component overrides (Button, Card, Inputs, Typography color override)
- App root now uses AppRouter
- Added VSCode settings for formatting, import sorting, eslint on save
- Added MCP config for MUI docs assistance Housekeeping:
- Removed unused ExampleButton component
- Updated copilot-instructions with detailed checklist and workflow rules
- Adjusted .gitignore to allow committed .vscode settings